### PR TITLE
Add a terraform proxy script using flock to avoid concurrent init runs

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ghcr.io/${{github.repository_owner}}/crossplane-terraform-provider
-          tags: type=raw,value=${{env.PROVIDER_VERSION}}-${{env.TERRAFORM_VERSION}}-${{env.KUBECTL_VERSION}}
+          tags: type=raw,value=${{env.PROVIDER_VERSION}}-${{env.TERRAFORM_VERSION}}-${{env.KUBECTL_VERSION}}-flock
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,8 @@ ARG TARGETARCH
 ENV TINI_VERSION v0.19.0
 ADD --chmod=555 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /sbin/tini
 
-COPY --from=terraform /bin/terraform /usr/local/bin/terraform
+ADD terraform.sh /usr/local/bin/terraform
+
+COPY --from=terraform /bin/terraform /usr/local/bin/terraform-exec
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/
 ENTRYPOINT ["tini", "--", "crossplane-terraform-provider"]

--- a/terraform.sh
+++ b/terraform.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Check if first argument is 'init'
+if [ "$1" = "init" ]; then
+    # Use exec with flock to ensure exclusive access during terraform init without forking
+    # The lock file will be created in /tmp
+    exec flock /tmp/terraform-init.lock terraform-exec "$@"
+else
+    # For all other commands, just pass through to terraform
+    exec terraform-exec "$@"
+fi


### PR DESCRIPTION
## Description

Add a terraform proxy script using flock to avoid concurrent init runs.

## Changes Made


## Related Issues

Relates to https://github.com/zaphiro-technologies/k8s-apps/issues/440 but could be not needed

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on DEMO
- [x] I have added appropriate documentation or updated existing documentation.
