### PR TITLE
Remove workflow_call from Project Management workflow

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -8,7 +8,6 @@ on:
     types:
       - labeled
       - ready_for_review
-  workflow_call:
   schedule:
     - cron: 0 0 * * *
 jobs:


### PR DESCRIPTION
Removes workflow_call to allow scheduled execution to work reliably.