### PR TITLE
Standardize issue management workflows

### DIFF
--- a/.github/workflows/add-to-project.yaml
+++ b/.github/workflows/add-to-project.yaml
@@ -8,8 +8,6 @@ on:
     types:
       - labeled
       - ready_for_review
-  schedule:
-    - cron: 0 0 * * *
 jobs:
   add-to-project:
     uses: zaphiro-technologies/github-workflows/.github/workflows/add-to-project.yaml@main

--- a/.github/workflows/manage-issues.yaml
+++ b/.github/workflows/manage-issues.yaml
@@ -1,0 +1,9 @@
+name: Manage Issues and PRs
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+jobs:
+  add-to-project:
+    uses: zaphiro-technologies/github-workflows/.github/workflows/manage-issues.yaml@main
+    secrets: inherit

--- a/.github/workflows/manage-issues.yaml
+++ b/.github/workflows/manage-issues.yaml
@@ -1,7 +1,7 @@
 name: Manage Issues and PRs
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "15 3 * * *"
   workflow_dispatch:
 jobs:
   add-to-project:


### PR DESCRIPTION
Removes the schedule trigger from add-to-project.yaml and introduces manage-issues.yaml for centralized issue and PR management.