### PR TITLE
Rename manage-issues workflow job

### DIFF
--- a/.github/workflows/manage-issues.yaml
+++ b/.github/workflows/manage-issues.yaml
@@ -4,6 +4,6 @@ on:
     - cron: "15 3 * * *"
   workflow_dispatch:
 jobs:
-  add-to-project:
+  manage-issues:
     uses: zaphiro-technologies/github-workflows/.github/workflows/manage-issues.yaml@main
     secrets: inherit


### PR DESCRIPTION
Renames the job `add-to-project` to `manage-issues` in manage-issues.yaml.