### PR TITLE
Build from Alpine 3.23.3 and update provider

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,2 @@
+[credential]
+	helper = store --file=$GIT_CRED_DIR/.git-credentials

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      PROVIDER_VERSION: 1.1.1
+      PROVIDER_VERSION: 1.1.2
       TERRAFORM_VERSION: 1.11.3
       KUBECTL_VERSION: 1.35.3
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,30 @@ ARG KUBECTL_VERSION
 
 FROM hashicorp/terraform:${TERRAFORM_VERSION} as terraform
 FROM alpine/kubectl:${KUBECTL_VERSION} as kubectl
+FROM xpkg.upbound.io/upbound/provider-terraform:v${PROVIDER_VERSION} as provider
 
-FROM xpkg.upbound.io/upbound/provider-terraform:v${PROVIDER_VERSION}
+FROM alpine:3.23.3
 
 # Add Tini
 ARG TARGETARCH
 ENV TINI_VERSION v0.19.0
 ADD --chmod=555 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /sbin/tini
 
+RUN apk --no-cache add ca-certificates bash git curl
+
+ENV TF_IN_AUTOMATION=1
+ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
+
+ADD .gitconfig .gitconfig
+
+# As of Crossplane v1.3.0 provider controllers run as UID 2000.
+# https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
+RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} && chown -R 2000 /tf
+
+COPY --from=provider /usr/local/bin/crossplane-terraform-provider /usr/local/bin/crossplane-terraform-provider
 COPY --from=terraform /bin/terraform /usr/local/bin/terraform
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/
+
+USER 65532
+
 ENTRYPOINT ["tini", "--", "crossplane-terraform-provider"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ ARG TARGETARCH
 ENV TINI_VERSION v0.19.0
 ADD --chmod=555 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /sbin/tini
 
-RUN apk --no-cache add ca-certificates bash git curl
+RUN apk --no-cache add -u zlib ca-certificates bash git curl
 
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ ADD .gitconfig .gitconfig
 RUN mkdir -p ${TF_PLUGIN_CACHE_DIR} && chown -R 2000 /tf
 
 COPY --from=provider /usr/local/bin/crossplane-terraform-provider /usr/local/bin/crossplane-terraform-provider
+COPY --from=provider /package.yaml /package.yaml
+COPY --from=provider /models/ /models/
 COPY --from=terraform /bin/terraform /usr/local/bin/terraform
 COPY --from=kubectl /usr/local/bin/kubectl /usr/local/bin/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,7 @@ FROM xpkg.upbound.io/upbound/provider-terraform:v${PROVIDER_VERSION} AS provider
 
 FROM alpine:3.23.3
 
-# Add Tini
-ARG TARGETARCH
-ENV TINI_VERSION=v0.19.0
-ADD --chmod=555 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /sbin/tini
-
-RUN apk --no-cache add -u zlib ca-certificates bash git curl
+RUN apk --no-cache add -u zlib ca-certificates bash git curl tini
 
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN apk --no-cache add -u zlib ca-certificates bash git curl
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 
-ADD .gitconfig .gitconfig
+COPY .gitconfig .gitconfig
 
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-ARG PROVIDER_VERSION
-ARG TERRAFORM_VERSION
-ARG KUBECTL_VERSION
+ARG PROVIDER_VERSION=1.1.2
+ARG TERRAFORM_VERSION=1.11.3
+ARG KUBECTL_VERSION=1.35.3
 
-FROM hashicorp/terraform:${TERRAFORM_VERSION} as terraform
-FROM alpine/kubectl:${KUBECTL_VERSION} as kubectl
-FROM xpkg.upbound.io/upbound/provider-terraform:v${PROVIDER_VERSION} as provider
+FROM hashicorp/terraform:${TERRAFORM_VERSION} AS terraform
+FROM alpine/kubectl:${KUBECTL_VERSION} AS kubectl
+FROM xpkg.upbound.io/upbound/provider-terraform:v${PROVIDER_VERSION} AS provider
 
 FROM alpine:3.23.3
 
 # Add Tini
 ARG TARGETARCH
-ENV TINI_VERSION v0.19.0
+ENV TINI_VERSION=v0.19.0
 ADD --chmod=555 https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-${TARGETARCH} /sbin/tini
 
 RUN apk --no-cache add -u zlib ca-certificates bash git curl

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,16 @@
 # Crossplane Terraform Provider Release Notes
 
-## 0.0.1-dev - 2024-06-26
+## 0.0.1-dev - 2026-04-14
+
+### Continuous Integration
+
+- Add scheduled trigger to Project Management workflow (PR #6 by @chicco785)
+
+### Security
+
+- Build from Alpine 3.23.3 and update provider (PR #15 by @cosimomeli)
 
 ### Dependencies
 
+- Bump actions/checkout from 4 to 6 (PR #5 by @dependabot[bot])
 - Bump docker/build-push-action from 5 to 6 (PR #1 by @dependabot[bot])


### PR DESCRIPTION
## Description

Build from Alpine 3.23.3 and update provider.

## Changes Made

- Build from Alpine 3.23.3
- Update provider to 1.1.2

## Related Issues

Relates to https://github.com/zaphiro-technologies/k8s-apps/issues/518

## Checklist

- [x] I have used a PR title that is descriptive enough for a release note.
- [ ] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [x] I have tested these changes on DEMO
- [ ] I have added appropriate documentation or updated existing documentation.
